### PR TITLE
Fix refresh bug on Cloudflare Pages

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,23 +1,25 @@
 <!DOCTYPE html>
 <html lang="en" data-theme="dark">
-	<head>
-		<meta charset="utf-8" />
-		<meta name="description" content="Real estate productivity software" />
-		<meta name="theme-color" content="#11191f" />
-		<link rel="icon" href="%sveltekit.assets%/logo-128.png" />
-		<link rel="apple-touch-icon" href="%sveltekit.assets%/logo-apple.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<meta name="theme-color" content="darkslategray" />
-		<link rel="manifest" href="/manifest.json" />
-		<link
-			rel="stylesheet"
-			href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css"
-		/>
-		<title>OpenAgent</title>
-		%sveltekit.head%
-	</head>
 
-	<body>
-		%sveltekit.body%
-	</body>
+<head>
+	<meta charset="utf-8" />
+	<meta name="description" content="Real estate productivity software" />
+	<meta name="theme-color" content="#11191f" />
+	<link rel="icon" href="%sveltekit.assets%/logo-128.png" />
+	<link rel="apple-touch-icon" href="%sveltekit.assets%/logo-apple.png" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta name="theme-color" content="darkslategray" />
+	<link rel="manifest" href="/manifest.json" />
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css" />
+	<title>OpenAgent</title>
+	%sveltekit.head%
+</head>
+
+<body>
+	%sveltekit.body%
+	<!-- Cloudflare Web Analytics -->
+	<script defer src='https://static.cloudflareinsights.com/beacon.min.js'
+		data-cf-beacon='{"token": "f8873a705b3847ffba0be8d582d5a596"}'></script><!-- End Cloudflare Web Analytics -->
+</body>
+
 </html>


### PR DESCRIPTION
When refreshing the chat or files page, a 500 server error will show at the [Cloudflare Pages deployment](https://open-agent.pages.dev).

This same error does not occur at the [Vercel deployment](https://open-agent.vercel.app) or in my local development server.

The error will clear and the app will begin functioning normally when clicking on any of the nav links in the navigation bar.

